### PR TITLE
expose types in package.json `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-justified-layout",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Flickr's justified-layout in a React hook",
   "author": "Alan Morales",
   "repository": {
@@ -46,6 +46,7 @@
   "module": "./dist/use-justified-layout.es.js",
   "exports": {
     ".": {
+      "types": "./dist/lib/main.d.ts",
       "import": "./dist/use-justified-layout.es.js",
       "require": "./dist/use-justified-layout.umd.js"
     }


### PR DESCRIPTION
my LSP isn't importing the types from this package when using `pnpm`:
```
Could not find a declaration file for module 'use-justified-layout'. '/path/to/node_module/dist/use-justified-layout.es.js' implicity has an 'any' type.
    There are types at '/path/to/node_module/dist/lib/main.d.ts', but this result could not be resolved when respecting package.json "exports". The 'use-justified-layout' library may need to update its package.json or typings.
```

adding the path to the types file to the exports resolves this